### PR TITLE
Ditch support for PHP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: php
 sudo: false
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Requirements
 
-- PHP 5.4 or newer
+- PHP 5.5 or newer
 - [Composer](http://getcomposer.org)
 
 ## Usage


### PR DESCRIPTION
Because `::class` is used in unit tests.

To fix the build.
