### PR TITLE
Added support for vendor:publish config file in Laravel

### DIFF
--- a/src/CorsServiceProvider.php
+++ b/src/CorsServiceProvider.php
@@ -15,6 +15,8 @@ class CorsServiceProvider extends ServiceProvider
         // In Lumen application configuration files needs to be loaded implicitly
         if ($this->app instanceof \Laravel\Lumen\Application) {
             $this->app->configure(self::CONFIG_KEY);
+        } else {
+            $this->publishes([$this->configPath() => config_path('cors.php')]);
         }
 
         $this->registerBindings();
@@ -44,5 +46,15 @@ class CorsServiceProvider extends ServiceProvider
         if (!class_exists('Cors')) {
             class_alias(CorsFacade::class, 'Cors');
         }
+    }
+
+    /**
+     * Default config file path
+     *
+     * @return string
+     */
+    protected function configPath()
+    {
+        return __DIR__ . '/../config/cors.php';
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:

 *  Added support for vendor publish in Laravel. By running this command, it will copy default config file to proper place (`/config/cors.php`).

```
php artisan vendor:publish --provider="Nord\Lumen\Cors\CorsServiceProvider"
```

I'm not sure if we want to do this, since the name of the package is `Lumen/Cors`. But I think it may be useful.