### PR TITLE
Adding a *.domain.tld possibilty

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6",
-		"league/uri": "4.2.3"
+	"league/uri": "4.2.3"
     },
     "require-dev": {
         "laravel/lumen-framework": "^5.4",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6",
-	"league/uri": "4.2.3"
+        "league/uri": "4.2.3"
     },
     "require-dev": {
         "laravel/lumen-framework": "^5.4",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "league/uri": "^5.3"
+		"league/uri": "4.2.3"
     },
     "require-dev": {
         "laravel/lumen-framework": "^5.4",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=5.6"
+        "php": ">=5.6",
+        "league/uri": "^5.3"
     },
     "require-dev": {
         "laravel/lumen-framework": "^5.4",

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -393,7 +393,7 @@ class CorsService implements CorsServiceContract
             // UriParser consider (rightly) *. as an invalid subdomain, so we have to replace it
             $wildcardDomain = str_replace('*', 'wildcard', $domain);
             $domainParsed = $parser->parse($wildcardDomain);
-            if ($domainParsed['scheme'] == $originParsed['scheme']) {
+            if ($domainParsed['scheme'] === $originParsed['scheme']) {
                 // Same protocol, next step
                 $domainHost = str_replace('wildcard', '*', $domainParsed['host']);
                 /* 

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -356,6 +356,42 @@ class CorsService implements CorsServiceContract
         if ($this->isAllOriginsAllowed()) {
             return true;
         }
+	    
+    	if (preg_match('#\*\.#', implode('|', $this->allowOrigins)) !== false) {
+			//All subdomains should match !
+			$domains = array();
+			foreach ($this->allowOrigins as $entry) {
+				if (preg_match('#\*\.#', $entry) !== false) {
+					$domains[] = $entry;
+				}
+			}
+			//Let's split the comparaison to scheme://host:port as in https://tools.ietf.org/html/rfc6454#section-7.1
+			$originProtocol = substr($origin, 0, strpos($origin, '://'));
+			$originHost = str_replace($originProtocol.'://', '', $origin);
+			$originHost = substr($originHost, 0, strpos($originHost, ':'));
+			$originPort = substr($originHost, strpos($originHost, ':')+1);
+
+			foreach ($domains as $domain) {
+				$domainProtocol = substr($domain, 0, strpos($domain, '://'));
+				if ($domainProtocol == $originProtocol) {
+					//Same protocol, next step
+					$domainHost = str_replace($domainProtocol.'://', '', $domain);
+					//Escape all the dots
+					$domainHostRE = str_replace('.', '\.', $domainHost);
+					/* 
+					 * Create the final RegExp, like (.*\.)?example\.com
+					 * This would match :
+					 *  - example.com
+					 *  - www.example.com
+					 *  - subdomain.example.com
+					 */
+					$domainHostRE = str_replace('*\.', '(.*\.)?', $domainHostRE);
+					if (preg_match('#'.$domainHostRE.'#', $originHost) !== false) {
+						return true;
+					}
+				}
+			}
+		}
 
         return in_array($origin, $this->allowOrigins);
     }
@@ -379,42 +415,6 @@ class CorsService implements CorsServiceContract
         if ($this->isAllMethodsAllowed()) {
             return true;
         }
-        
-        if (preg_match('#\*\.#', implode('|', $this->allowOrigins)) !== false) {
-			//All subdomains should match !
-			$domains = array();
-			foreach ($this->allowOrigins as $entry) {
-				if (preg_match('#\*\.#', $entry) !== false) {
-					$domains[] = $entry;
-				}
-			}
-			//Let's split the comparaison to scheme://host:port as in https://tools.ietf.org/html/rfc6454#section-7.1
-			$originProtocol = substr($origin, 0, strpos($origin, '://'));
-			$originHost = str_replace($originProtocol.'://', '', $origin);
-			$originHost = substr($originHost, 0, strpos($originHost, ':'));
-			$originPort = substr($originHost, strpos($originHost, ':')+1);
-			
-			foreach ($domains as $domain) {
-				$domainProtocol = substr($domain, 0, strpos($domain, '://'));
-				if ($domainProtocol == $originProtocol) {
-					//Same protocol, next step
-					$domainHost = str_replace($domainProtocol.'://', '', $domain);
-					//Escape all the dots
-					$domainHostRE = str_replace('.', '\.', $domainHost);
-					/* 
-					 * Create the final RegExp, like (.*\.)?example\.com
-					 * This would match :
-					 *  - example.com
-					 *  - www.example.com
-					 *  - subdomain.example.com
-					 */
-					$domainHostRE = str_replace('*\.', '(.*\.)?', $domainHostRE);
-					if (preg_match('#'.$domainHostRE.'#', $originHost) !== false) {
-						return true;
-					}
-				}
-			}
-		}
 
         return in_array(strtoupper($method), $this->allowMethods);
     }

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -489,7 +489,7 @@ class CorsService implements CorsServiceContract
     {
         $matchedOrigins = $this->getWildcardOrigins();
         
-        return (count($matchedOrigins) > 0);
+        return count($matchedOrigins) > 0;
     }
 
     /**

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -357,11 +357,11 @@ class CorsService implements CorsServiceContract
         if ($this->isAllOriginsAllowed()) {
             return true;
         }
-	    
-    	if ($this->hasWildcardOrigins()) {
-	    if ($this->isOriginInWildcardOrigins($origin)) {
-	        return true;
-	    }
+        
+        if ($this->hasWildcardOrigins()) {
+            if ($this->isOriginInWildcardOrigins($origin)) {
+                return true;
+            }
         }
 
         return in_array($origin, $this->allowOrigins);
@@ -386,15 +386,15 @@ class CorsService implements CorsServiceContract
         $matchedOrigins = $this->getWildcardOrigins();
         $hasMatch = false;
 
-        //Lets parse the uri to extract some parts
+        // Let's parse the URI to extract some parts
         $parser = new UriParser();
         $originParsed = $parser->parse($origin);
         foreach ($matchedOrigins as $domain) {
-            //UriParser consider (rightly) *. as an invalid subdomain, so we have to replace it
+            // UriParser consider (rightly) *. as an invalid subdomain, so we have to replace it
             $wildcardDomain = str_replace('*', 'wildcard', $domain);
             $domainParsed = $parser->parse($wildcardDomain);
             if ($domainParsed['scheme'] == $originParsed['scheme']) {
-                //Same protocol, next step
+                // Same protocol, next step
                 $domainHost = str_replace('wildcard', '*', $domainParsed['host']);
                 /* 
                  * Create the final RegExp, like (.*\.)?example\.com
@@ -403,9 +403,9 @@ class CorsService implements CorsServiceContract
                  *  - www.example.com
                  *  - subdomain.example.com
                  */
-                //Escape all the dots
+                // Escape all the dots
                 $domainHostRE = str_replace('.', '\.', $domainHost);
-                //Place the RegExp
+                // Place the RegExp in the string
                 $domainHostRE = str_replace('*\.', '(.+\.)?', $domainHostRE);
 
                 if (preg_match('#'.$domainHostRE.'#', $originParsed['host']) !== 0) {
@@ -477,7 +477,7 @@ class CorsService implements CorsServiceContract
       */
     protected function getWildcardOrigins()
     {
-        //We'll search for an *. in all the allowed origins
+        // We'll search for an *. in all the allowed origins
         return preg_grep('#\*\.#', $this->allowOrigins);
     }
 
@@ -487,8 +487,8 @@ class CorsService implements CorsServiceContract
     protected function hasWildcardOrigins()
     {
         $matchedOrigins = $this->getWildcardOrigins();
-	
-	return (count($matchedOrigins) > 0);
+        
+        return (count($matchedOrigins) > 0);
     }
 
     /**

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -406,6 +406,8 @@ class CorsService implements CorsServiceContract
                 $domainHostRE = str_replace('.', '\.', $domainHost);
                 // Place the RegExp in the string
                 $domainHostRE = str_replace('*\.', '(.+\.)?', $domainHostRE);
+                // Adding a end $ to not match example.com.evil
+                $domainHostRE = $domainHostRE.'$';
 
                 if (preg_match('#'.$domainHostRE.'#', $originParsed['host']) !== 0) {
                     return true;

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -384,8 +384,7 @@ class CorsService implements CorsServiceContract
         }
 
         $matchedOrigins = $this->getWildcardOrigins();
-        $hasMatch = false;
-
+		
         // Let's parse the URI to extract some parts
         $parser = new UriParser();
         $originParsed = $parser->parse($origin);
@@ -409,12 +408,12 @@ class CorsService implements CorsServiceContract
                 $domainHostRE = str_replace('*\.', '(.+\.)?', $domainHostRE);
 
                 if (preg_match('#'.$domainHostRE.'#', $originParsed['host']) !== 0) {
-                    $hasMatch = true;
+                    return true;
                 }
             }
         }
 
-        return $hasMatch;
+        return false;
     }
 
     /**

--- a/src/CorsService.php
+++ b/src/CorsService.php
@@ -473,11 +473,12 @@ class CorsService implements CorsServiceContract
 	
 	
     /**
+      * Return an array of all the allowed origins that match *.
+	  *
       * @return array
       */
     protected function getWildcardOrigins()
     {
-        // We'll search for an *. in all the allowed origins
         return preg_grep('#\*\.#', $this->allowOrigins);
     }
 


### PR DESCRIPTION
I read quickly RFC's and CORS website, it doesn't allow nor disallow this; I needed it, it may be useful to somebody else.

Changes proposed in this pull request:

 * Allow to have a `'allow_origins' => ['https://*.example.com']` to match all subdomains from example.com

