### PR TITLE
Add support for PHP 8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["7.1", "7.2", "7.3", "7.4", "8.0"]
+        php-version: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Changes proposed in this pull request:

 * PHP 8.1 was released on 2021-11-25
 * Add it to the test matrix
